### PR TITLE
Ignore node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ static/.sass-cache
 
 config.dev.ini
 nbproject/
+
+/node_modules


### PR DESCRIPTION
I think it's generally considered bad practice to include node_modules in one's git repository. Rather, users should be instructed to get them via `npm install`. 