### PR TITLE
Fix wrong class name for medium warning

### DIFF
--- a/src/css/timings.scss
+++ b/src/css/timings.scss
@@ -319,7 +319,7 @@ section {
 	color: red;
 }
 
-.warn-medium {
+.warn-med {
 	color: #ff7820;
 }
 


### PR DESCRIPTION
The element [gets generated](https://github.com/aikar/timings/blob/e9e7c9b44a6e815301941c847253b5e7b108a20d/src/js/globals.js#L79) with the class `warn-med` but the style uses `warn-medium` leading to a white coloring instead of the supposed orange one. This fixes that by using the correct class name in the style.