### PR TITLE
Replace mention of inactive #spigot IRC channel

### DIFF
--- a/src/js/ui/ContentWrapper.jsx
+++ b/src/js/ui/ContentWrapper.jsx
@@ -24,7 +24,7 @@ export default class ContentWrapper extends React.Component {
     return <div>
       <Header />
       <div id="body-wrap">
-        <div className="dev-warning"><strong>Please do not ask for help with timings in #spigot</strong></div>
+        <div className="dev-warning"><strong>Please do not ask for help with timings on the SpigotMC forums or their Discord</strong></div>
 
 
         <ContentTop/>


### PR DESCRIPTION
This replaces the mention of the pretty much inactive #spigot IRC channel with the SpigotMC forums and Discord.