### PR TITLE
Very mis-leading!

### DIFF
--- a/src/js/ui/ServerInfo.jsx
+++ b/src/js/ui/ServerInfo.jsx
@@ -95,7 +95,7 @@ function analyzeFlags() {
         return <span style={{color: 'red'}}>✗ ZGC is not performing well for you, Switch to G1 <a href="https://mcflags.emc.gs" >FIX THIS</a></span>;
       }
     }
-    const fixGC = "Switch Java flags to stop receiving lag spikes.";
+    const fixGC = "Switch to Aikar's flags!";
     if (gc["PS Scavenge"]) {
       return <span style={{color: 'red'}}>✗ Wrong Garbage Collector <a href="https://mcflags.emc.gs" >FIX THIS</a>
         <br />{fixGC}</span>;


### PR DESCRIPTION
This is very misleading.... Setting your servers flags to Aikar's is not a magical fix for lag. The timings website should not be telling users that this is a fix for lag.

Whilst Aikar's flags can be a fix for some lag, it is mis-leading in the fact that this is the first thing that people see when visiting the timings website. Instead, maybe have a look at other issues in your timings report?

Please consider changing this text to something not so mis-leading.