### PR TITLE
Updated outdated IRC reference to forum/Discord

### DIFF
--- a/src/js/ui/ContentWrapper.jsx
+++ b/src/js/ui/ContentWrapper.jsx
@@ -24,7 +24,7 @@ export default class ContentWrapper extends React.Component {
     return <div>
       <Header />
       <div id="body-wrap">
-        <div className="dev-warning"><strong>Please do not ask for help with timings in #spigot</strong></div>
+        <div className="dev-warning"><strong>Please do not ask for help with timings on the SpigotMC forums or in the Spigot Discord</strong></div>
 
 
         <ContentTop/>


### PR DESCRIPTION
The IRC channel reference is extremely outdated nowadays imo seeing as that is basically dead now. Updated it with something more modern.