### PR TITLE
Add more system info (Resolves #80)

### DIFF
--- a/lib/Json/TimingsSystemData.php
+++ b/lib/Json/TimingsSystemData.php
@@ -17,12 +17,16 @@ class TimingsSystemData {
 	use FromJson;
 
 	public $timingcost;
+	public $loadavg;
 	public $name;
 	public $version;
 	public $jvmversion;
+	public $jvmvendor;
+	public $jvmvendorversion;
 	public $arch;
 	public $maxmem;
 	public $cpu;
+	public $cpuname;
 	public $runtime;
 	public $flags;
 	public $gc;

--- a/src/js/data/TimingsSystemData.js
+++ b/src/js/data/TimingsSystemData.js
@@ -16,12 +16,16 @@ import {ObjectBase} from "objectsm";;
 export default class TimingsSystemData extends ObjectBase {
 
   timingcost;
+  loadavg;
   name;
   version;
   jvmversion;
+  jvmvendor;
+  jvmvendorversion;
   arch;
   maxmem;
   cpu;
+  cpuname;
   runtime;
   flags;
   gc;


### PR DESCRIPTION
This adds more information to the system data (CPU and JVM vendor from PaperMC/Paper#7490) as well as the missing loadavg which has been submitted but never actually used.

I'm unsure if this is really all that's needed to get them to display as I was unable to get a test setup of timings running due to outdated/broken nodejs dependencies :S